### PR TITLE
update deprecated mapped types link ex5

### DIFF
--- a/src/exercises/5/index.solution.ts
+++ b/src/exercises/5/index.solution.ts
@@ -104,5 +104,5 @@ filterUsers(
 ).forEach(logPerson);
 
 // In case if you are stuck:
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types
+// https://www.typescriptlang.org/docs/handbook/utility-types.html
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types

--- a/src/exercises/5/index.ts
+++ b/src/exercises/5/index.ts
@@ -104,5 +104,5 @@ filterUsers(
 ).forEach(logPerson);
 
 // In case if you are stuck:
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types
+// https://www.typescriptlang.org/docs/handbook/utility-types.html
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types

--- a/src/exercises/6/index.solution.ts
+++ b/src/exercises/6/index.solution.ts
@@ -85,4 +85,4 @@ console.log('Admins of age 23:');
 adminsOfAge23.forEach(logPerson);
 
 // In case if you are stuck:
-// https://www.typescriptlang.org/docs/handbook/functions.html#overloads
+// https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads

--- a/src/exercises/6/index.ts
+++ b/src/exercises/6/index.ts
@@ -81,4 +81,4 @@ console.log('Admins of age 23:');
 adminsOfAge23.forEach(logPerson);
 
 // In case if you are stuck:
-// https://www.typescriptlang.org/docs/handbook/functions.html#overloads
+// https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads


### PR DESCRIPTION
Hello!

Updating deprecated link to  [utility types link](https://www.typescriptlang.org/docs/handbook/utility-types.html) which is used at the bottom of exercise 5.
Not sure what was on the original `advanced-types.html#mapped-types` page, but the proposed link contains helpful information for the exercise.

Edited: Also changed the deprecated link in exercise 6.