### PR TITLE
Exercise 1: change the stub code to contain an interface

### DIFF
--- a/src/exercises/1/index.ts
+++ b/src/exercises/1/index.ts
@@ -76,7 +76,7 @@ Exercise:
 
 */
 
-export type User = unknown;
+export interface User
 
 export const users: unknown[] = [
     {


### PR DESCRIPTION
Exercise 1 asks to define an interface, however the stub code contains a type:

`export type User = unknown;`

This can be a bit confusing especially since it's the first exercise.