### PR TITLE
IsNotAny checks any and any[]

### DIFF
--- a/src/exercises/node_modules/type-assertions/index.ts
+++ b/src/exercises/node_modules/type-assertions/index.ts
@@ -17,10 +17,11 @@ export type IsTypeAssignable<T1, T2> = IsNotAny<T1> extends false ? false : (
 );
 
 /**
- * Returns `false` if `any` is specified, otherwise returns `true`.
+ * Returns `false` if `any` or `any[]` is specified, otherwise returns `true`.
  * @see https://stackoverflow.com/a/49928360/3406963
  */
-export type IsNotAny<T> = 0 extends (1 & T) ? false : true;
+
+export type IsNotAny<T> = 0 extends (1 & T) ? false : ( 0 extends (1 & ArrayElement<T>) ? false : true);
 
 /**
  * Returns true for false and vice versa.


### PR DESCRIPTION
Thank you for this useful project!

I wrote the wrong solution (I don't understand why it does not work till now), but the tests passed.

<details>
  <summary>My wrong solution</summary>
  
  ```javascript
  type GeneralMapper = (value: any) => any;
type Mapper<I extends GeneralMapper, O> = (value: O) => ReturnType<I>;


type MapperFunc = {
    (): MapperFunc;
    <I extends GeneralMapper, O>(subInput: Array<O>): Array<any>;
}

export function map(): typeof map;
export function map<I extends GeneralMapper, O>(mapper: Mapper<I, O>): MapperFunc;
export function map<I extends GeneralMapper, O>(mapper: Mapper<I, O>, input: Array<O>): Array<ReturnType<Mapper<I, O>>>

export function map<I extends GeneralMapper, O>(mapper?: Mapper<I, O>, input?: Array<O>): Array<ReturnType<Mapper<I, O>>> | typeof map | MapperFunc {
    if (arguments.length === 0) {
        return map;
    }
    if (arguments.length === 1) {
        function subFunction(): typeof subFunction;
        function subFunction<O>(subInput: Array<O>): Array<Mapper<any, O>>;

        function subFunction<O>(subInput?: Array<O>): Array<Mapper<any, O>> | typeof subFunction {
            if (arguments.length === 0) {
                return subFunction;
            }
            return subInput!.map(mapper! as unknown as Mapper<I, O>);
        };

        return subFunction;
    }
    return input!.map(mapper!);
}
  ```
  
</details>

<img width="573" alt="wrong-ok" src="https://user-images.githubusercontent.com/6074289/122525189-aa9f5900-d021-11eb-968d-d92d2be04bf9.png">

I suggest fix for tests, which adds the ability to catch this case.