### PR TITLE
Exercise 15: Remove unneeded "Object" keyword

### DIFF
--- a/src/exercises/15/index.ts
+++ b/src/exercises/15/index.ts
@@ -27,7 +27,6 @@ Exercise:
 
 */
 
-Object
 export class ObjectManipulator {
 
     constructor(protected obj) {}


### PR DESCRIPTION
There is an unneeded `Object` keyword above the class definition in exercise 15, which has most likely been added by mistake.

It is interpreted as a statement that just refers to the Object identifier and doesn't do anything with it. Because of Automatic Semicolon Insertion, it also doesn't interfere with the `export class` following it.
It is a bit confusing though, as it is not immediately clear if the `Object` has significance there (e.g. on a quick glance, it might look like a decorator).

It is also not included in `index.solution.ts`.