### PR TITLE
Exercise 6 improvement with Indexed Access Type

### DIFF
--- a/src/exercises/6/index.solution.ts
+++ b/src/exercises/6/index.solution.ts
@@ -60,9 +60,9 @@ export function logPerson(person: Person) {
 
 const getObjectKeys = <T>(obj: T) => Object.keys(obj) as (keyof T)[];
 
-export function filterPersons(persons: Person[], personType: 'user', criteria: Partial<Omit<User, 'type'>>): User[];
-export function filterPersons(persons: Person[], personType: 'admin', criteria: Partial<Omit<Admin, 'type'>>): Admin[];
-export function filterPersons(persons: Person[], personType: string, criteria: Partial<Person>): Person[] {
+export function filterPersons(persons: Person[], personType: User['type'], criteria: Partial<Omit<User, 'type'>>): User[];
+export function filterPersons(persons: Person[], personType: Admin['type'], criteria: Partial<Omit<Admin, 'type'>>): Admin[];
+export function filterPersons(persons: Person[], personType: Person['type'], criteria: Partial<Person>): Person[] {
     return persons
         .filter((person) => person.type === personType)
         .filter((person) => {


### PR DESCRIPTION
I think the [Indexed Access Type](https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html) feature would be great in the exercice to:
- avoid duplicated string literal types (`'user'` and `'admin'` here)
- use a more precise type than `'string'` in the implementation signature (consequently, only `'admin'` and `'user'` would be allowed in the other functions signatures)