### PR TITLE
Improved diff for Exercise 1

### DIFF
--- a/src/exercises/1/index.ts
+++ b/src/exercises/1/index.ts
@@ -63,7 +63,7 @@ Brief UI guide:
 Intro:
 
     We are starting a small community of users. For performance
-    reasons we have decided to store all users right in the code.
+    reasons, we have decided to store all users right in the code.
     This way we can provide our developers with more
     user-interaction opportunities. With user-related data, at least.
     All the GDPR-related issues will be solved some other day.


### PR DESCRIPTION
Adds a comma into code comment to stop the diff checker reporting an unnecessary change.

e.g: when we run the diff test on exercise 1 before we make any changes, this is what you used to see and what you now see:

| Before | After |
| --- | --- |
| <img width="1512" alt="before" src="https://github.com/typescript-exercises/typescript-exercises/assets/2376795/23b6a99e-e0f0-43a1-88f7-74c81b2f0c3c"> | <img width="1512" alt="after" src="https://github.com/typescript-exercises/typescript-exercises/assets/2376795/c69fdf6b-d246-4e30-8331-dc545758e5e2"> |