### PR TITLE
change parameters to correct order at practice 14

### DIFF
--- a/src/exercises/14/test.ts
+++ b/src/exercises/14/test.ts
@@ -37,10 +37,10 @@ typeAssert<IsTypeEqual<typeof subtractResult1, number>>();
 const subtractResult2 = subtract(2, 1);
 typeAssert<IsTypeEqual<typeof subtractResult2, number>>();
 
-const propResult1 = prop()('x')()({x: 1, y: 'Hello'});
+const propResult1 = prop()({x: 1, y: 'Hello'})()('x');
 typeAssert<IsTypeEqual<typeof propResult1, number>>();
 
-const propResult2 = prop('y', {x: 1, y: 'Hello'});
+const propResult2 = prop({x: 1, y: 'Hello'}, 'y');
 typeAssert<IsTypeEqual<typeof propResult2, string>>();
 
 const pipeResult1 = pipe(filter(Boolean), map(String), reduce((a: string, b: string) => a + b, ''))([0, 1, 2, 3]);


### PR DESCRIPTION
on practice 14, the function signature is (obj, string) =>any, but in test.ts, it's called in (string, obj)=>any, so i fixed this problem in this commit